### PR TITLE
fix: relax dependencies

### DIFF
--- a/.github/workflows/tox_tests.yml
+++ b/.github/workflows/tox_tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6]
+        python: [3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ setup(
     packages=find_packages(),
     install_requires=[
         "click",
-        "pystac[validation]==1.0.0rc2",
+        # we can't use pystac>=1.12.0 because they did a major/breaking bump to
+        # the projection extension (v1.x to v2) that renamed proj:epsg -> proj:code.
+        "pystac[validation]>=1.0.0rc2,<1.12.0",
         "untangle",
         "geojson",
         "shapely",

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@ from setuptools import find_packages, setup
 
 setup(
     name="hls_cmr_stac",
-    version="0.1",
+    version="1.8",
     packages=find_packages(),
     install_requires=[
-        "click~=7.1.0",
+        "click",
         "pystac[validation]==1.0.0rc2",
         "untangle",
         "geojson",
         "shapely",
-        "rasterio==1.2.10",
+        "rasterio",
     ],
     include_package_data=True,
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py312
 
 [testenv]
 envdir = venv


### PR DESCRIPTION
## Description

This PR relaxes the Click dependency so this can be installed against a more modern set of dependencies in our atmospheric correction container.

I updated the tests to run on a newer version of Python to modernize in general, but specifically because the CI failed to install Python 3.6 since it's deprecated.

The removal of pins on rasterio and click are fairly trivial.

Of note is the re-pin for `pystac`,
1. `pystac[validation]==1.0.0rc2` doesn't work against modern versions of `jsonschema`. Instead of pinning `jsonschema` I opted to bump `pystac` (ref https://github.com/stac-utils/pystac/pull/857)
2. `pystac==1.12.0` introduces a breaking change in the `proj` extension (`proj:epsg` -> `proj:code`) that was caught in our tests 🙏.
3. `pystac<=1.12.0` is still on STAC version `1.0.0`, but I'm also going to specify in our container that we should be using `stac==1.0.0` by defining the `PYSTAC_STAC_VERSION_OVERRIDE` envvar