### PR TITLE
feat: include LaSRC and Fmask versions

### DIFF
--- a/hls_cmr_stac/hls_cmr_stac.py
+++ b/hls_cmr_stac/hls_cmr_stac.py
@@ -345,6 +345,20 @@ def process_scientific(item, granule):
             scientific_extension.doi = attribute.Values.Value.cdata
 
 
+def process_software_versions(item, granule):
+    software = {}
+    for attribute in granule.AdditionalAttributes.AdditionalAttribute:
+        if attribute.Name == "ACCODE":
+            software["Atmospheric Correction"] = attribute.Values.Value.cdata
+        if attribute.Name == "CLOUD_MASKING_CODE":
+            software["Cloud Masking"] = attribute.Values.Value.cdata
+    if software:
+        item.stac_extensions.append(
+            "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+        )
+        item.properties["processing:software"] = software
+
+
 def cmr_to_item(cmrxml, endpoint, version):
     band1_file = f"{os.path.splitext(os.path.splitext(cmrxml)[0])[0]}.B01.tif"
     cmr = untangle.parse(cmrxml)
@@ -370,6 +384,7 @@ def cmr_to_item(cmrxml, endpoint, version):
     process_projection(item, granule, band1_file)
     process_view_geometry(item, granule)
     process_scientific(item, granule)
+    process_software_versions(item, granule)
     item.validate()
     feature = item.to_dict()
     return feature

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="hls_cmr_stac",
-    version="1.8",
+    version="1.9",
     packages=find_packages(),
     install_requires=[
         "click",

--- a/tests/data/HLS.L30.T19LBJ.2020239T144556.v2.0.cmr.xml
+++ b/tests/data/HLS.L30.T19LBJ.2020239T144556.v2.0.cmr.xml
@@ -202,6 +202,12 @@
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>
+      <Name>CLOUD_MASKING_CODE</Name>
+      <Values>
+        <Value>Fmask v4.7</Value>
+      </Values>
+    </AdditionalAttribute>
+    <AdditionalAttribute>
       <Name>TIRS_SSM_MODEL</Name>
       <Values>
         <Value>FINAL</Value>

--- a/tests/data/HLS.S30.T35VLJ.2021168T100559.v2.0.cmr.xml
+++ b/tests/data/HLS.S30.T35VLJ.2021168T100559.v2.0.cmr.xml
@@ -285,6 +285,12 @@
       </Values>
     </AdditionalAttribute>
     <AdditionalAttribute>
+      <Name>CLOUD_MASKING_CODE</Name>
+      <Values>
+        <Value>Fmask v4.7</Value>
+      </Values>
+    </AdditionalAttribute>
+    <AdditionalAttribute>
       <Name>PROCESSING_BASELINE</Name>
       <Values>
         <Value>03.00</Value>

--- a/tests/test_hls_cmr_stac.py
+++ b/tests/test_hls_cmr_stac.py
@@ -34,6 +34,14 @@ def test_cmr_to_item_s30():
     assert item["assets"]["B01"]["roles"][0] == "data"
     assert item["assets"]["thumbnail"]["roles"][0] == "thumbnail"
     assert item["properties"]["sci:doi"] == "10.5067/HLS/HLSS30.002"
+    assert item["properties"]["processing:software"] == {
+        "Atmospheric Correction": "LaSRC v3.1.0",
+        "Cloud Masking": "Fmask v4.7",
+    }
+    assert (
+        "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+        in item["stac_extensions"]
+    )
 
 
 def test_cmr_to_item_l30():
@@ -64,3 +72,11 @@ def test_cmr_to_item_l30():
     assert item["assets"]["B01"]["roles"][0] == "data"
     assert item["assets"]["thumbnail"]["roles"][0] == "thumbnail"
     assert item["properties"]["sci:doi"] == "10.5067/HLS/HLSL30.002"
+    assert item["properties"]["processing:software"] == {
+        "Atmospheric Correction": "LaSRC v3.0.5",
+        "Cloud Masking": "Fmask v4.7",
+    }
+    assert (
+        "https://stac-extensions.github.io/processing/v1.2.0/schema.json"
+        in item["stac_extensions"]
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ envlist = py312
 envdir = venv
 extras =
   test
-  flake8
 commands =
     pytest
 


### PR DESCRIPTION
This PR addresses https://github.com/NASA-IMPACT/hls_development/issues/407

- Forward `ACCODE` and `CLOUD_MASKING_CODE` from the CMR XML file into the STAC Item
- Use the `processing:software` field to define metadata
- Update tests
- Bump version in anticipation of new release